### PR TITLE
Support for 3044 and several smaller fixes

### DIFF
--- a/AveryLabels.py
+++ b/AveryLabels.py
@@ -62,9 +62,9 @@ class AveryLabel:
         self.canvas.setLineCap(1)
 
     def topLeft(self, x=None, y=None):
-        if x == None:
+        if x is None:
             x = self.position
-        if y == None:
+        if y is None:
             if self.topDown:
                 x,y = divmod(x, self.down)
             else:

--- a/AveryLabels.py
+++ b/AveryLabels.py
@@ -1,7 +1,7 @@
 import os
 from collections.abc import Iterator
 from reportlab.pdfgen import canvas
-from reportlab.lib.pagesizes import LETTER, landscape
+from reportlab.lib.pagesizes import A4, landscape
 from reportlab.lib.units import inch, mm, cm
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
@@ -22,20 +22,21 @@ from reportlab.pdfbase.ttfonts import TTFont
 # label size w/h
 # label gutter across/down
 # page margins left/top
+# page size w/h or name from reportlab.lib.pagesizes
 
 labelInfo = {
     # 2.6 x 1 address labels
-    5160: ( 3, 10, (187,  72), (11, 0), (14, 36)),
-    5161: ( 2, 10, (288,  72), (0, 0), (18, 36)),
+    5160: ( 3, 10, (187,  72), (11, 0), (14, 36), A4),
+    5161: ( 2, 10, (288,  72), (0, 0), (18, 36), A4),
     # 4 x 2 address labels
-    5163: ( 2,  5, (288, 144), (0, 0), (18, 36)),
+    5163: ( 2,  5, (288, 144), (0, 0), (18, 36), A4),
     # 1.75 x 0.5 return address labels
-    5167: ( 4, 20, (126,  36), (0, 0), (54, 36)),
+    5167: ( 4, 20, (126,  36), (0, 0), (54, 36), A4),
     # 3.5 x 2 business cards
-    5371: ( 2,  5, (252, 144), (0, 0), (54, 36)),
+    5371: ( 2,  5, (252, 144), (0, 0), (54, 36), A4),
 
     # 48x 45.7x21.2mm 
-    4778: (4, 12, (45.7*mm, 21.2*mm), (0.25*cm, 0), (1.1*cm, 2*cm) ),
+    4778: (4, 12, (45.7*mm, 21.2*mm), (0.25*cm, 0), (1.1*cm, 2*cm), A4),
 }
 
 class AveryLabel:
@@ -49,7 +50,7 @@ class AveryLabel:
         self.margins = data[4]
         self.topDown = True
         self.debug = False
-        self.pagesize = LETTER
+        self.pagesize = data[5]
         self.position = 0
         self.__dict__.update(kwargs)
 

--- a/AveryLabels.py
+++ b/AveryLabels.py
@@ -1,10 +1,7 @@
-import os
 from collections.abc import Iterator
 from reportlab.pdfgen import canvas
-from reportlab.lib.pagesizes import A4, landscape
-from reportlab.lib.units import inch, mm, cm
-from reportlab.pdfbase import pdfmetrics
-from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.units import mm, cm
 
 # Usage:
 #   label = AveryLabels.AveryLabel(5160)

--- a/AveryLabels.py
+++ b/AveryLabels.py
@@ -25,6 +25,9 @@ from reportlab.pdfbase.ttfonts import TTFont
 # page size w/h or name from reportlab.lib.pagesizes
 
 labelInfo = {
+    # 22x 32mm x 10mm mini labels
+    3044: ( 2, 11, (32, 10), (2,2), (1, 1), (66.5*mm, 120.5*mm)),
+
     # 2.6 x 1 address labels
     5160: ( 3, 10, (187,  72), (11, 0), (14, 36), A4),
     5161: ( 2, 10, (288,  72), (0, 0), (18, 36), A4),

--- a/main.py
+++ b/main.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 import AveryLabels
 from reportlab.lib.units import mm, cm
 from reportlab_qrcode import QRCodeImage
@@ -96,10 +99,15 @@ def render(c: canvas.Canvas, width: float, height: float):
             c.restoreState()
 
 
-fileName = "out/labels-" + str(labelForm) + "-" + str(mode) + ".pdf"
+outputDirectory = 'out'
+fileName = os.path.join(outputDirectory, f"labels-{labelForm}-{mode}.pdf")
 
 label = AveryLabels.AveryLabel(labelForm)
 label.debug = debug
+try:
+    os.makedirs(outputDirectory, exist_ok=True)
+except OSError as oe:
+    sys.exit(f"Failed to create directory '{outputDirectory}': {oe}")
 label.open(fileName)
 label.render(render, count=labelsToPrint, offset=offsetLabels)
 label.close()

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import AveryLabels
-from reportlab.lib.units import mm, cm
+from reportlab.lib.units import mm
 from reportlab_qrcode import QRCodeImage
 from reportlab.pdfgen import canvas
 


### PR DESCRIPTION
I added support for [Avery Zweckform 3044 Mini ](https://www.avery-zweckform.com/produkt/vielzweck-etiketten-3044) labels and improved/fixed a few minor things.
See the commits for more details.