### PR TITLE
Add rotation correction

### DIFF
--- a/AveryLabels.py
+++ b/AveryLabels.py
@@ -2,6 +2,7 @@ from collections.abc import Iterator
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import A4, letter
 from reportlab.lib.units import mm, cm, inch
+from math import atan, degrees
 
 # Usage:
 #   label = AveryLabels.AveryLabel(5160)
@@ -55,6 +56,7 @@ class AveryLabel:
         self.down = data[1]
         self.size = data[2]
         self.labelsep = self.size[0]+data[3][0], self.size[1]+data[3][1]
+        self.labelsTotalWidth = data[0] * data[2][0] + (data[0]-1) * data[3][0]
         self.margins = data[4]
         self.topDown = True
         self.debug = False
@@ -95,6 +97,9 @@ class AveryLabel:
         self.canvas.save()
         self.canvas = None
 
+    def calculateRotationDegrees(self, rotateOffset):
+        return degrees(atan(rotateOffset/self.labelsTotalWidth))
+
     # To render, you can either create a template and tell me
     # "go draw N of these templates" or provide a callback.
     # Callback receives canvas, width, height.
@@ -102,12 +107,13 @@ class AveryLabel:
     # Or, pass a callable and an iterator.  We'll do one label
     # per iteration of the iterator.
 
-    def render( self, thing, count, offset=0, *args ):
+    def render( self, thing, count, offset=0, rotateOffset=0, *args ):
         assert callable(thing) or isinstance(thing, str)
         if isinstance(count, Iterator):
             return self.render_iterator( thing, count )
 
         canv = self.canvas
+        canv.rotate(self.calculateRotationDegrees(rotateOffset))
         for i in range(offset+count):
             if i >= offset:
                 canv.saveState()

--- a/main.py
+++ b/main.py
@@ -28,6 +28,8 @@ labelsAlreadyPrinted = 20
 labelsCorrupted = 4
 # how many labels should be printed now
 labelsToPrint = 18
+# set this to 3 if the top left corner of your labels is in the correct position but your top right corner is 3 mm too far down
+rotateOffset = -1*mm
 
 fontSize = 2*mm
 qrSize = 0.9
@@ -109,7 +111,7 @@ try:
 except OSError as oe:
     sys.exit(f"Failed to create directory '{outputDirectory}': {oe}")
 label.open(fileName)
-label.render(render, count=labelsToPrint, offset=offsetLabels)
+label.render(render, count=labelsToPrint, offset=offsetLabels, rotateOffset=rotateOffset)
 label.close()
 
 print


### PR DESCRIPTION
My printer is not very accurate, so all the prints come out a bit skewed like this (effect dramatized for illustration):

<img width="1460" height="337" alt="Bildschirmfoto 2025-07-22 um 16 01 54" src="https://github.com/user-attachments/assets/6b6b44a2-44ad-4863-ab1c-6bfa8f70ffbe" />

This means that even if the top left label fits perfectly, the bottom right won't.

To fix this I introduced a new setting allowing for compensation of this rotation error by doing a test print and measuring how far the labels need to be rotated. Simply measure how far up or down the top-right corner of the label sheet has to move up or down and set `rotateOffset` to that distance. The rotation angle will be calculated as the arctan of offset/totalLabelsWidth

<img width="1408" height="398" alt="drawing" src="https://github.com/user-attachments/assets/ae0d866e-51df-4e2c-b11b-9f11b469c0dc" />

